### PR TITLE
Accept more general Basic Auth password file format

### DIFF
--- a/trac/web/auth.py
+++ b/trac/web/auth.py
@@ -324,11 +324,11 @@ class BasicAuthentication(PasswordFileAuthentication):
         self.hash = {}
         with open(filename) as fd:
             for line in fd:
-                line = line.strip()
+                line = line.split('#')[0].strip()
                 if not line:
                     continue
                 try:
-                    u, h = line.split(':')
+                    u, h = line.split(':')[:2]
                 except ValueError:
                     print("Warning: invalid password line in %s: %s"
                           % (filename, line), file=sys.stderr)


### PR DESCRIPTION
The trac standalone [can use Apache's htpasswd files](https://trac.edgewall.org/wiki/TracStandalone#BasicAuthorization:Usingahtpasswdpasswordfile) for authentication.  Although Apache *creates* an htpasswd file with format `user:password`, it *understands* files with additional components after those first two.  For example, [dokuwiki](https://www.dokuwiki.org/auth:plain) uses the format `user:password:Real Name:email:groups` to provide additional information on each user.  Such a file also works with Apache and nginx HTTP Basic Auth; they just ignore the remaining fields.  But `tracd` breaks, because it expects exactly two components.

Perhaps more importantly, other tools respect comments in htpasswd.  So, for example, if you want to disable user `joey12`, you can comment out that user's line by putting `#` in front.  But `tracd` just processes that as `#joey12`, which could potentially allow a login under that name.

This pull request adds the ability to handle those more general htpasswd file formats.  It simply removes everything after a `#`, and then only takes the first two components of any remaining lines.

[Technically, Apache only considers a line a comment if it *begins with* `#`; I think this behavior is safer for htpasswd files, especially since this makes it less likely that this function will dump passwords to the error log.]