### PR TITLE
Fix one missed `_has_perms_for_action` in default_workflow

### DIFF
--- a/trac/ticket/default_workflow.py
+++ b/trac/ticket/default_workflow.py
@@ -497,7 +497,7 @@ class ConfigurableTicketWorkflow(Component):
                    if operation in info['operations'] and
                       ('*' in info['oldstates'] or
                        status in info['oldstates']) and
-                      self._has_perms_for_action(req, info, ticket.resource)]
+                      self._is_action_allowed(req, info, ticket.resource)]
         return actions
 
     # Public methods


### PR DESCRIPTION
Fix one missed occurrence of renamed function.

Addition to https://trac.edgewall.org/changeset/15912/trunk