### PR TITLE
Enhanced Search Result Ordering

### DIFF
--- a/trac/attachment.py
+++ b/trac/attachment.py
@@ -335,6 +335,30 @@ class AttachmentModule(Component):
         `resource_realm.realm` whose filename, description or author match
         the given terms.
         """
+
+        def filenamerating(filename, query):
+            query = query.lower()
+            filename = filename.lower()
+            if filename.startswith("/trac/attachment/wiki/"):
+                filename = filename.partition("/trac/attachment/wiki/")[2]
+            basefilename = filename.rpartition('.')[0]
+            if filename == query:
+                # best case: filename matches searchterm
+                return 5
+            elif basefilename.endswith(query):
+                # slightly worse: filename without extension ends with searchterm
+                return 4
+            elif query in basefilename:
+                # slightly worse: filename without extension contains searchterm
+                return 3
+            else:
+                return 2
+
+        def descriptionrating(description, query):
+            query = query.lower()
+            description = description.lower()
+            return description.count(query)
+
         with self.env.db_query as db:
             sql_query, args = search_to_sql(
                     db, ['filename', 'description', 'author'], terms)
@@ -344,10 +368,12 @@ class AttachmentModule(Component):
                     (resource_realm.realm,) + args):
                 attachment = resource_realm(id=id).child(self.realm, filename)
                 if 'ATTACHMENT_VIEW' in req.perm(attachment):
+                    order = (filenamerating(filename, terms[0]), 0, descriptionrating(desc, terms[0]), time)
                     yield (get_resource_url(self.env, attachment, req.href),
                            get_resource_shortname(self.env, attachment),
                            from_utimestamp(time), author,
-                           shorten_result(desc, terms))
+                           shorten_result(desc, terms),
+                           order)
 
     # IResourceManager methods
 

--- a/trac/search/api.py
+++ b/trac/search/api.py
@@ -37,7 +37,16 @@ class ISearchSource(Interface):
         being the name of the tuples returned by `get_search_events`.
 
         The events returned by this function must be tuples of the form
-        `(href, title, date, author, excerpt).`
+        `(href, title, date, author, excerpt)`. Optionally, a sixth value
+        `order` could be included:
+
+        `order` is supposed to contain a quadtuple which is to be composed of
+        * rating for pagename/filename
+        * rating for headings
+        * rating for description/content
+        * timestamp
+        Rating are evaluated in this order.
+        In each case, a higher value will signify a more relevant search result.
         """
 
 

--- a/trac/search/web_ui.py
+++ b/trac/search/web_ui.py
@@ -234,7 +234,12 @@ class SearchModule(Component):
         for source in self.search_sources:
             results.extend(source.get_search_results(req, terms, filters)
                            or [])
-        return sorted(results, key=lambda x: x[2], reverse=True)
+        # backwarts compatibility: add empty order parameter if none is included
+        results = [x if len(x) == 6 else x + (0, 0, 0, 0) for x in results]
+        # sort by order parameter
+        sortedresults = sorted(results, key=lambda x: x[5], reverse=True)
+        # remove order parameter
+        return [(href, title, date, author, excerpt) for (href, title, date, author, excerpt, order) in sortedresults]
 
     def _prepare_results(self, req, filters, results):
         page = req.args.getint('page', 1, min=1)

--- a/trac/ticket/web_ui.py
+++ b/trac/ticket/web_ui.py
@@ -197,6 +197,16 @@ class TicketModule(Component):
             yield ('ticket', _("Tickets"))
 
     def get_search_results(self, req, terms, filters):
+        def summary_rating(summary, query):
+            query = query.lower()
+            summary = summary.lower()
+            return summary.count(query)
+
+        def description_rating(description, query):
+            query = query.lower()
+            description = description.lower()
+            return description.count(query)
+
         if 'ticket' not in filters:
             return
         ticket_realm = Resource(self.realm)
@@ -223,6 +233,7 @@ class TicketModule(Component):
                           args + args2 + args3):
                 t = ticket_realm(id=tid)
                 if 'TICKET_VIEW' in req.perm(t):
+                    order = (summary_rating(summary, terms[0]), 0, description_rating(description, terms[0]), ts)
                     yield (req.href.ticket(tid),
                            tag_("%(title)s: %(message)s",
                                 title=tag.span(
@@ -231,7 +242,8 @@ class TicketModule(Component):
                                 message=ticketsystem.format_summary(
                                     summary, status, resolution, type)),
                            from_utimestamp(ts), author,
-                           shorten_result(desc, terms))
+                           shorten_result(desc, terms),
+                           order)
 
         # Attachments
         for result in AttachmentModule(self.env).get_search_results(


### PR DESCRIPTION
I was looking for a solution to enhance the usefulness of trac search results. Stock trac seems to sort search results by the date of last change, which might not always be what users expect. Looking for a medium solution between using complete indexing server as suggested in https://trac.edgewall.org/wiki/AdvancedSearch and the current solution, I suggest a medium solution (with regard to both complexity and quality), ordering the results based on occurrence of the search word in page/ticket title, headers and content.

The `ISearchSource` `get_search_results()` gets an optional sixth value in the return tuple called `order` which is supposed to contain a quadtuple which is to be composed of
 * rating for pagename/filename
 * rating for headings
 * rating for description/content
 * timestamp
The `order` parameter is then used to sort search results. The ratings are evaluated in above order. In each case, a higher value will signify a more relevant search result.