### PR TITLE
Util: fix is_path_below() when parent is root path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ trac/htdocs/js/messages/*.js
 .project
 .pydevproject
 .settings
+.DS_Store

--- a/trac/util/__init__.py
+++ b/trac/util/__init__.py
@@ -575,7 +575,10 @@ def is_path_below(path, parent):
         return os.path.normcase(os.path.abspath(path))
     path = normalize(path)
     parent = normalize(parent)
-    return path == parent or path.startswith(parent + os.sep)
+    try:
+        return os.path.commonpath((path, parent)) == parent
+    except ValueError:
+        return False
 
 
 class file_or_std(object):

--- a/trac/util/tests/__init__.py
+++ b/trac/util/tests/__init__.py
@@ -113,6 +113,17 @@ class PathTestCase(unittest.TestCase):
         self.assertFalse(util.is_path_below('../sub/repos',
                                             os.path.join(os.getcwd())))
 
+    def test_is_path_below_root_parent(self):
+        path = os.path.abspath(os.path.join(os.sep, 'tmp'))
+        self.assertTrue(util.is_path_below(path, os.sep))
+
+        if os.name == 'nt':
+            cwd = os.path.abspath(os.getcwd())
+            drive, _ = os.path.splitdrive(cwd)
+            drive_root = drive + os.sep
+            self.assertTrue(util.is_path_below(drive_root + 'tmp',
+                                               drive_root))
+
     def test_native_path(self):
         self.assertIsNone(util.native_path(None))
         if os.name == 'posix':


### PR DESCRIPTION
## Summary

This PR fixes an edge case in `trac.util.is_path_below()` when the parent path is a filesystem root.

## Problem

The previous implementation used string prefix matching:

- `path == parent or path.startswith(parent + os.sep)`

This fails for root parents (for example `/` on POSIX, and drive roots on Windows), because appending `os.sep` to a root path does not produce a reliable boundary check.

## Solution

Replaced the prefix check with `os.path.commonpath(...)`.

## Tests

Added a regression test in `PathTestCase`:
